### PR TITLE
Ensure quickstart flow works without testServerId

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -29,11 +29,13 @@ const applicationPublicKey = application?.applicationPublicKey;
 const applicationSecret = application?.applicationSecret;
 
 // Validate environment
-function assert(name, value) {
-  if (!value) throw new Error(`${name} must be set in env.jsonc`);
+function assert(name, value, warn = false) {
+  if (value) return;
+  if (!warn) throw new Error(`${name} must be set in env.jsonc`);
+  console.warn(`Warning: ${name} is not set in env.jsonc. You must set it to interact with Discord.`);
 }
 if (mode === "development") {
-  assert("testServerId", testServerId);
+  assert("testServerId", testServerId, true);
   assert("development.applicationId", applicationId);
   assert("development.applicationPublicKey", applicationPublicKey);
   assert("development.applicationSecret", applicationSecret);


### PR DESCRIPTION
If you follow the [quickstart instructions](https://github.com/mrbbot/slshx#quickish-start) and run `npm run dev` before setting a `testServerId`, the development process exits early due to the `assert` method listed in the build script.

This prevents a developer from booting the landing page and clicking "Add to Server."

This commit modifies the behavior of this assertion to include a `warn` optional boolean. If truthy, the process will not exist but will rather `console.warn()` to let the developer know a value is missing.